### PR TITLE
Add chit_chats_domestic_tracked postage type

### DIFF
--- a/sections/shipments.md
+++ b/sections/shipments.md
@@ -327,6 +327,7 @@ _Enumeration values_:
   * `ups_other` - UPS Other Mail Class
   * `fedex_other` - FedEx Other Mail Class
   * `chit_chats_canada_tracked` - Chit Chats Canada Tracked
+  * `chit_chats_domestic_tracked` - Chit Chats Domestic Tracked (alternative to Chit Chats Canada Tracked, limited availability)
   * `chit_chats_international_not_tracked` - Chit Chats International Standard
   * `dhl_other` - DHL Other Mail Class
   * `asendia_ipa` - Asendia International Priority Airmail


### PR DESCRIPTION
Alternative postage type to chit_chats_canada_tracked, offered to select regions: Ontario, Quebec, Atlantic Canada