### PR TITLE
Add public tracking API instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ API endpoints
 -------------
 - [Batches](https://github.com/chitchats/chitchats-api-doc/blob/master/sections/batches.md)
 - [Shipments](https://github.com/chitchats/chitchats-api-doc/blob/master/sections/shipments.md)
+- [Tracking](https://github.com/chitchats/chitchats-api-doc/blob/master/sections/tracking.md)
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ You can perform up to 2000 requests per 5 minute period from the same IP address
 
 We recommend baking 429 response-handling in to your HTTP handling at a low level so your integration handles retries gracefully and automatically.
 
+Testing
+-------
+
+We run a testing/sandbox site at https://staging.chitchats.com that you can use to test your API integration without actually buying postage.  You will need to create a separate account on this site to use it.  To add credits use credit card number 4111 1111 1111 1111 with any expiry and CVC.
+
 API endpoints
 -------------
 - [Batches](https://github.com/chitchats/chitchats-api-doc/blob/master/sections/batches.md)

--- a/sections/tracking.md
+++ b/sections/tracking.md
@@ -1,0 +1,56 @@
+Tracking
+=========
+
+You can get public tracking events as JSON from any recent Chit Chats shipment ID by adding a `.json` suffix to the public tracking URL.
+
+E.g., if the Chit Chats shipment ID was B5T85U7E1C you can get the public
+tracking page at:  
+https://chitchats.com/tracking/b5t85u7e1c
+
+and the JSON tracking page at:  
+https://chitchats.com/tracking/b5t85u7e1c.json
+
+
+###### Copy as cURL
+```shell
+curl -s "https://chitchats.com/tracking/b5t85u7e1c.json"
+```
+
+###### Example JSON Request
+```json
+{
+  shipment: {
+    shipment_id: "B5T85U7E1C",
+    to_city: "DEL RIO",
+    to_province_code: "TX",
+    to_postal_code: "78840-3384",
+    to_country_code: "US",
+    from_city: null,
+    from_province_code: null,
+    from_postal_code: null,
+    from_country_code: null,
+    package_description: "Parcel",
+    size_description: "1 × 1 × 1 cm",
+    weight_description: "0.3 lb",
+    resolution: "unknown",
+    postage_description: "Unknown Unknown",
+    estimated_delivery_at: null,
+    carrier: "unknown",
+    carrier_description: "Unknown",
+    carrier_tracking_code: null,
+    tracking_url: "https://chitchats.com/tracking/b5t85u7e1c",
+    ship_date: "2019-02-18",
+    resolution_description: "Expected Delivery",
+    resolved_at: null,
+    tracking_events: [
+      {
+      title: "Shipment created, Chit Chats awaiting item",
+      subtitle: null,
+      location_description: null,
+      created_at: "2019-01-26T17:28:59.797-08:00",
+      status: null
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
Update documentation to include notes on testing the API and the public tracking API.
