### PR TITLE
Add return_address information and note to shipments

### DIFF
--- a/sections/shipments.md
+++ b/sections/shipments.md
@@ -385,6 +385,10 @@ _Enumeration values_:
   * `cad` - Canadian Dollar
   * `usd` - US Dollar
 
+You can optionally pass the `return_address` fields i.e. `return_name`, `return_address_1`, `return_address_2`, `return_city`, `return_province_code`, `return_postal_code`, `return_phone`.
+
+Note: Only US Return Address can be requested for a shipment, so no need to send return_country_code param. Return Address is determined when postage is bought. We will use the provided address if the postage allows it, otherwise we ignore the address provided and pick default address for that postage.
+
 ###### Example JSON Request
 ```json
 {


### PR DESCRIPTION
**Background**

We have recently updated our API [#2860](https://github.com/venturemedia/chitchats/pull/2860) to allow `return_address` to be passed when creating shipments. This PR add this to the docs and mentions a note about how US return addresses are determined during shipments' buy postage stage.

**Satisfaction Criteria**
- [ ] Shipments create section to have updated information.
